### PR TITLE
Disagg fake device

### DIFF
--- a/hw/misc/Kconfig
+++ b/hw/misc/Kconfig
@@ -1,3 +1,8 @@
+config DISAGG_FAKE_PCI
+    bool
+    default y if PCI_DEVICES
+    depends on PCI
+
 config APPLESMC
     bool
     depends on ISA_BUS

--- a/hw/misc/disagg_fake_pci.c
+++ b/hw/misc/disagg_fake_pci.c
@@ -1,0 +1,86 @@
+// Sources for some code: 
+// https://www.qemu.org/docs/master/devel/qom.html
+// https://blog.davidv.dev/posts/learning-pcie/
+// https://github.com/airbus-seclab/qemu_blog/blob/main/pci_slave.md
+// Harsha's shmem api in the libvfio-user subproject tran_sock.c file
+
+#include "qemu/osdep.h"
+
+#include "hw/hw.h"
+#include "hw/pci/pci_bridge.h"
+#include "hw/qdev-properties.h"
+
+/*
+ * All those values are set iniside the EDU init class function
+ */
+#define DISAGG_VENDOR_ID PCI_VENDOR_ID_QEMU
+#define DISAGG_DEVICE_ID (0x11e8)
+#define DISAGG_REVISION (0x10)
+#define DISAGG_CLASS_ID (PCI_CLASS_OTHERS)
+
+#define TYPE_DISAGG_FAKE_PCI "disagg-fake-pci"
+OBJECT_DECLARE_SIMPLE_TYPE(DisaggFakePCIDevice, DISAGG_FAKE_PCI)
+
+struct DisaggFakePCIDevice {
+    PCIDevice pdev;
+    uint64_t bar_size;
+    MemoryRegion bar0;
+};
+
+// No additions to this class, so reuse parent class
+typedef PCIDeviceClass DisaggFakePCIDeviceClass;
+
+static void disagg_fake_pci_device_realize(PCIDevice *pdev, Error **errp)
+{
+    printf("Disagg_fake_pci_device_realize\n");
+
+    DisaggFakePCIDevice *dev = DISAGG_FAKE_PCI(pdev);
+    //PCIDeviceClass* pclass = PCI_DEVICE_GET_CLASS(pdev);
+
+    memory_region_init_io(&dev->bar0, OBJECT(dev), NULL, NULL, "disagg-fake-pci-mmio", dev->bar_size);
+    pci_register_bar(pdev, /* BAR nr. */ 0, PCI_BASE_ADDRESS_SPACE_MEMORY, &dev->bar0);
+}
+
+static Property disagg_fake_device_properties[] = {
+    DEFINE_PROP_UINT64("bar-size", DisaggFakePCIDevice, bar_size, 0),
+};
+
+static void disagg_fake_device_instance_init(Object *obj)
+{
+    printf("disagg_fake_device_instance_init\n");
+}
+
+static void disagg_fake_device_class_init(ObjectClass *klass, void *data)
+{
+    printf("disagg_fake_device_class_init\n");
+
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    PCIDeviceClass *pdc = PCI_DEVICE_CLASS(klass);
+
+    device_class_set_props(dc, disagg_fake_device_properties);
+    dc->desc = "Disagg fake pci device for remote EDU";
+    pdc->realize = disagg_fake_pci_device_realize;
+    pdc->vendor_id = DISAGG_VENDOR_ID;
+    pdc->device_id = DISAGG_DEVICE_ID;
+    pdc->revision = DISAGG_REVISION;
+    pdc->class_id = DISAGG_CLASS_ID;
+}
+
+static const TypeInfo disagg_fake_device_info = {
+    .name = TYPE_DISAGG_FAKE_PCI,
+    .parent = TYPE_PCI_DEVICE,
+    .instance_size = sizeof(DisaggFakePCIDevice),
+    .instance_init = disagg_fake_device_instance_init,
+    .class_init = disagg_fake_device_class_init,
+    .interfaces = (InterfaceInfo[]) {
+	{ INTERFACE_CONVENTIONAL_PCI_DEVICE },
+	{ },
+    },
+};
+
+static void disagg_fake_device_register_type(void)
+{
+    type_register_static(&disagg_fake_device_info);
+}
+
+type_init(disagg_fake_device_register_type);

--- a/hw/misc/edu.c
+++ b/hw/misc/edu.c
@@ -151,13 +151,17 @@ static void edu_dma_timer(void *opaque)
         uint64_t dst = edu->dma.dst;
         edu_check_range(dst, edu->dma.cnt, DMA_START, DMA_SIZE);
         dst -= DMA_START;
-        pci_dma_read(&edu->pdev, edu_clamp_addr(edu, edu->dma.src),
+	// removed the edu_clamp_addr call for the src address
+	// wouldn't work otherwise, because there wouldn't be enough space in the address space limited to 28bits
+        pci_dma_read(&edu->pdev, edu->dma.src,
                 edu->dma_buf + dst, edu->dma.cnt);
     } else {
         uint64_t src = edu->dma.src;
         edu_check_range(src, edu->dma.cnt, DMA_START, DMA_SIZE);
         src -= DMA_START;
-        pci_dma_write(&edu->pdev, edu_clamp_addr(edu, edu->dma.dst),
+	// removed the edu_clamp_addr call for the dst address
+	// wouldn't work otherwise, because there wouldn't be enough space in the address space limited to 28bits
+        pci_dma_write(&edu->pdev, edu->dma.dst,
                 edu->dma_buf + src, edu->dma.cnt);
     }
 

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -1,3 +1,4 @@
+system_ss.add(when: 'CONFIG_DISAGG_FAKE_PCI', if_true: files('disagg_fake_pci.c'))
 system_ss.add(when: 'CONFIG_APPLESMC', if_true: files('applesmc.c'))
 system_ss.add(when: 'CONFIG_EDU', if_true: files('edu.c'))
 system_ss.add(when: 'CONFIG_FW_CFG_DMA', if_true: files('vmcoreinfo.c'))

--- a/hw/remote/vfio-user-obj.c
+++ b/hw/remote/vfio-user-obj.c
@@ -327,7 +327,14 @@ static void dma_register(vfu_ctx_t *vfu_ctx, vfu_dma_info_t *info)
 
     dma_as = pci_device_iommu_address_space(o->pci_dev);
 
-    memory_region_add_subregion(dma_as->root, (hwaddr)iov->iov_base, subregion);
+    // necessary to not fail assertion (added because will propably be set further up the call stuck in normal case)
+    if (bql_locked()) {
+	memory_region_add_subregion(dma_as->root, (hwaddr)iov->iov_base, subregion);
+    } else {
+	bql_lock();
+	memory_region_add_subregion(dma_as->root, (hwaddr)iov->iov_base, subregion);
+	bql_unlock();
+    }
 
     trace_vfu_dma_register((uint64_t)iov->iov_base, iov->iov_len);
 }

--- a/subprojects/libvfio-user.wrap
+++ b/subprojects/libvfio-user.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
-url = https://github.com/maxjae/libvfio-user
-revision = 5c03ed46bccf473cbc17e749389249689f8608e8
+url = https://github.com/harshanavkis/libvfio-user
+revision = 81f874efc8b4b5a3447ef4d320b8b6fdfe0ffb10
 

--- a/subprojects/libvfio-user.wrap
+++ b/subprojects/libvfio-user.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
-url = https://github.com/harshanavkis/libvfio-user
-revision = 776d3204251bc093f10c2b6f693bccc063fe20cf
+url = https://github.com/maxjae/libvfio-user
+revision = 5c03ed46bccf473cbc17e749389249689f8608e8
 


### PR DESCRIPTION
Adds a fake device which is then discovered by kernel. Sets up BAR region. MMIO/DMA do not go through this implementation.